### PR TITLE
Consistent constructors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module pipelined.dev/audio
 
 require (
-	pipelined.dev/pipe v0.8.3
+	pipelined.dev/pipe v0.8.4
 	pipelined.dev/signal v0.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-pipelined.dev/pipe v0.8.3 h1:yiKbSs7bGKbJDHI+itNMuzWRZrMeW1X2+u3W9H3l5+Q=
-pipelined.dev/pipe v0.8.3/go.mod h1:VF3EecmES6UYXmO2yloIYgGgeCctUq2Dz0/h4GMjwAY=
+pipelined.dev/pipe v0.8.4 h1:UFyH26AWW3GkVOWIla9zQYqDzbWW6NwdFDnvsrCKwVg=
+pipelined.dev/pipe v0.8.4/go.mod h1:VF3EecmES6UYXmO2yloIYgGgeCctUq2Dz0/h4GMjwAY=
 pipelined.dev/signal v0.8.0 h1:L66vzenF0F6R2XhFy0pOftb83mFDkVqVugKnvs0eS7M=
 pipelined.dev/signal v0.8.0/go.mod h1:wi0YlA20+rinS9o+7IMZHH3/YsO3jkahHNLSCCfaEA0=

--- a/track_test.go
+++ b/track_test.go
@@ -118,10 +118,7 @@ func TestTrack(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		track := audio.Track{
-			SampleRate: sampleRate,
-			Channels:   channels,
-		}
+		track := audio.Track{}
 		for _, clip := range test.clips {
 			track.AddClip(clip.position, clip.data)
 		}
@@ -129,7 +126,7 @@ func TestTrack(t *testing.T) {
 		sink := &mock.Sink{}
 
 		l, _ := pipe.Routing{
-			Source: track.Source(0, 0),
+			Source: track.Source(sampleRate, 0, 0),
 			Sink:   sink.Sink(),
 		}.Line(2)
 


### PR DESCRIPTION
* Remove `audio.NewMixer` constructor;
* Remove `audio.Track` exported fields;

All types (Track, Asset and Mixer) now use construct literals.