### PR TITLE
Synchronised mixer

### DIFF
--- a/internal/semaphore/semaphore.go
+++ b/internal/semaphore/semaphore.go
@@ -10,9 +10,9 @@ type Semaphore struct {
 // New returns new initialized semaphore.
 func New(l int) Semaphore {
 	limit := make(chan struct{}, l)
-	for i := 0; i < l; i++ {
-		limit <- struct{}{}
-	}
+	// for i := 0; i < l; i++ {
+	// 	limit <- struct{}{}
+	// }
 	return Semaphore{
 		limit: limit,
 	}

--- a/internal/semaphore/semaphore.go
+++ b/internal/semaphore/semaphore.go
@@ -18,11 +18,15 @@ func New(l int) Semaphore {
 	}
 }
 
-// Acquire the lock.
-func (s *Semaphore) Acquire(ctx context.Context) {
+// Acquire the lock. Calling this method blocks until lock is obtained or
+// context is expired. Returns true if lock is obtained, false if context
+// is done.
+func (s *Semaphore) Acquire(ctx context.Context) bool {
 	select {
 	case <-s.limit:
+		return true
 	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/internal/semaphore/semaphore.go
+++ b/internal/semaphore/semaphore.go
@@ -1,0 +1,32 @@
+package semaphore
+
+import "context"
+
+// Semaphore implements semaphore synchronization primitive.
+type Semaphore struct {
+	limit chan struct{}
+}
+
+// New returns new initialized semaphore.
+func New(l int) Semaphore {
+	limit := make(chan struct{}, l)
+	for i := 0; i < l; i++ {
+		limit <- struct{}{}
+	}
+	return Semaphore{
+		limit: limit,
+	}
+}
+
+// Acquire the lock.
+func (s *Semaphore) Acquire(ctx context.Context) {
+	select {
+	case <-s.limit:
+	case <-ctx.Done():
+	}
+}
+
+// Release the lock.
+func (s *Semaphore) Release() {
+	s.limit <- struct{}{}
+}

--- a/internal/semaphore/semaphore_test.go
+++ b/internal/semaphore/semaphore_test.go
@@ -3,15 +3,20 @@ package semaphore_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"pipelined.dev/audio/internal/semaphore"
 )
 
 func TestSema(t *testing.T) {
 	sema := semaphore.New(1)
-	sema.Acquire(context.Background())
-	ctx, cancelFn := context.WithCancel(context.Background())
-	cancelFn()
-	sema.Acquire(ctx)
 	sema.Release()
+	ctx, cancelFn := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancelFn()
+	if !sema.Acquire(ctx) {
+		t.Fatalf("acquire should have succeeded")
+	}
+	if sema.Acquire(ctx) {
+		t.Fatalf("acquire should have failed")
+	}
 }

--- a/internal/semaphore/semaphore_test.go
+++ b/internal/semaphore/semaphore_test.go
@@ -1,0 +1,17 @@
+package semaphore_test
+
+import (
+	"context"
+	"testing"
+
+	"pipelined.dev/audio/internal/semaphore"
+)
+
+func TestSema(t *testing.T) {
+	sema := semaphore.New(1)
+	sema.Acquire(context.Background())
+	ctx, cancelFn := context.WithCancel(context.Background())
+	cancelFn()
+	sema.Acquire(ctx)
+	sema.Release()
+}

--- a/mixer.go
+++ b/mixer.go
@@ -159,6 +159,7 @@ func mix(ctx context.Context, frames frames, pool *signal.PoolAllocator, inputs 
 		if input.frame == head {
 			frames[next].expected = frames[head].expected - frames[head].flushed
 			frames[next].flushed = 0
+			frames[next].length = 0
 			frames[next].buffer = pool.GetFloat64()
 			head = next
 		}

--- a/mixer.go
+++ b/mixer.go
@@ -227,8 +227,9 @@ func (f *frame) sum() bool {
 	if f.added == 0 || f.added+f.flushed != f.expected {
 		return false
 	}
-	if f.buffer.Length() != f.length {
-		f.buffer = f.buffer.Slice(0, f.length)
+	if f.buffer.Len() != f.length {
+		// fmt.Printf("slice!")
+		f.buffer = f.buffer.Slice(0, f.length/f.buffer.Channels())
 	}
 	for i := 0; i < f.buffer.Len(); i++ {
 		f.buffer.SetSample(i, f.buffer.Sample(i)/float64(f.added))
@@ -242,8 +243,8 @@ func (f *frame) add(in signal.Floating) {
 	for i := 0; i < l; i++ {
 		f.buffer.SetSample(i, f.buffer.Sample(i)+in.Sample(i))
 	}
-	if f.length < in.Length() {
-		f.length = in.Length()
+	if f.length < in.Len() {
+		f.length = in.Len()
 	}
 	return
 }


### PR DESCRIPTION
Previous implementation offered unbound buffer for each mixer input. It might caused a situation when low-latency emits a lot of signal data and causes GC.

This PR adds semaphores for each input, meaning no more than single buffer is being mixed at the moment.